### PR TITLE
Reorganize README categories by tool ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,114 +3,154 @@ A curated list of awesome AI coding frameworks, workflows, patterns, tools and m
 
 ## Table of Contents
 - [AI Coding Frameworks](#ai-coding-frameworks)
-- [Workflow & Automation](#workflow-and-automation)
 - [Context Engineering](#context-engineering)
-- [Claude Code Tools & Extensions](#claude-code-tools-and-extensions)
-- [Agents & Sub-Agents](#agents-and-sub-agents)
-- [Development Tools & Utilities](#development-tools-and-utilities)
-- [Awesome Lists & Collections](#awesome-lists-and-collections)
-- [UI & Interface](#ui-and-interface)
-- [Monitoring & Analytics](#monitoring-and-analytics)
+- [Agents & Collaboration](#agents--collaboration)
+- [Development Tools & Utilities](#development-tools--utilities)
+- [Awesome Lists & Collections](#awesome-lists--collections)
+- [UI & Interface](#ui--interface)
+- [Claude Code Ecosystem](#claude-code-ecosystem)
+  - [Frameworks & Methodologies](#frameworks--methodologies)
+  - [Workflow & Automation](#workflow--automation)
+  - [Tools & Extensions](#tools--extensions)
+  - [Agents & Sub-Agents](#agents--sub-agents)
+  - [Skills Libraries](#skills-libraries)
+  - [Development Utilities](#development-utilities)
+  - [UI & Interface](#ui--interface-1)
+  - [Monitoring & Analytics](#monitoring--analytics)
+  - [Awesome Lists & Collections](#awesome-lists--collections-1)
+- [Kiro Ecosystem](#kiro-ecosystem)
+  - [Templates & Configs](#templates--configs)
 - [AI Coding Blogs](#ai-coding-blogs)
+- [Contributing](#contributing)
+- [Classification Methodology](#classification-methodology)
+- [License](#license)
+- [Acknowledgments](#acknowledgments)
 
 ## AI Coding Frameworks
 
-- [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD): Breakthrough Method for Agile Ai Driven Development ⭐ 13853 `🔤 JavaScript`
+- [BMAD-METHOD](https://github.com/bmad-code-org/BMAD-METHOD): Breakthrough Method for Agile AI Driven Development ⭐ 13853 `🔤 JavaScript`
 - [spec-kit](https://github.com/github/spec-kit): 💫 Toolkit to help you get started with Spec-Driven Development ⭐ 9338 `🔤 Python`
 - [agent-os](https://github.com/buildermethods/agent-os): Agent OS is a system for better planning and executing software development tasks with your AI agents. ⭐ 1446 `🔤 Shell`
 - [cc-sdd](https://github.com/gotalab/cc-sdd): Kiro compatible Spec-Driven Development for Claude Code, Gemini CLI and Cursor. High quality slash commands that enforce structured requirements→design→tasks workflow and steering, transforming how you build with AI ⭐ 954 `🔤 TypeScript`
-- [Disciplined-AI-Software-Development](https://github.com/Varietyz/Disciplined-AI-Software-Development): This methodology provides a structured approach for collaborating with AI systems on software development projects. It addresses common issues like code bloat, architectural drift, and context dilution through systematic constraints and validation checkpoints. ⭐ 267 `🔤 Python`
-- [claude-conductor](https://github.com/superbasicstudio/claude-conductor): Claude Conductor - a simple Claude Code framework ⭐ 188 `🔤 JavaScript`
-- [cc-sdd](https://github.com/pdoronila/cc-sdd): Spec Driven Development Workflow inside Claude-Code
-
-## Workflow & Automation
-
-- [claude-code-spec-workflow](https://github.com/Pimzino/claude-code-spec-workflow): Automated workflows for Claude Code. Features spec-driven development for new features (Requirements → Design → Tasks → Implementation) and streamlined bug fix workflow for quick issue resolution (Report → Analyze → Fix → Verify). ⭐ 2599 `🔤 TypeScript`
-- [claude-code-workflows](https://github.com/OneRedOak/claude-code-workflows): The best workflows and configurations I've developed, having heavily used Claude Code since the day of it's release. Workflows are based off applied learnings from our AI-native startup. ⭐ 2207
-- [crystal](https://github.com/stravu/crystal): Run multiple Claude Code AI sessions in parallel git worktrees. Test, compare approaches & manage AI-assisted development workflows in one desktop app. ⭐ 1826 `🔤 TypeScript`
-- [claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery): None ⭐ 1399 `🔤 Python`
-- [spec-workflow-mcp](https://github.com/Pimzino/spec-workflow-mcp): A Model Context Protocol (MCP) server that provides structured spec-driven development workflow tools for AI-assisted software development, featuring a real-time web dashboard and VSCode extension for monitoring and managing your project's progress directly in your development environment. ⭐ 1364 `🔤 TypeScript`
-- [Claude-Code-Development-Kit](https://github.com/peterkrueck/Claude-Code-Development-Kit): Handle context at scale - my custom Claude Code workflow including hooks, mcp and sub agents ⭐ 1049 `🔤 Shell`
-- [commands](https://github.com/wshobson/commands): A collection of production-ready slash commands for Claude Code ⭐ 673
-- [Claude-Command-Suite](https://github.com/qdhenry/Claude-Command-Suite): Professional slash commands for Claude Code that provide   structured workflows for software development tasks including   code review, feature creation, security auditing, and architectural analysis. ⭐ 652 `🔤 Shell`
-- [myclaude](https://github.com/cexll/myclaude): Cladue Code AI Team Workflow Sub Agents. ⭐ 635
-- [claude-commands](https://github.com/badlogic/claude-commands): Global Claude Code commands and workflows ⭐ 437
-- [claudecode-rule2hook](https://github.com/zxdxjtu/claudecode-rule2hook): Transform natural language project rules into Claude Code automation hooks - Write rules in plain English and let Claude  automatically generate powerful hooks for code formatting, testing, validation and more ⭐ 355 `🔤 Python`
-- [cc-sdd](https://github.com/pdoronila/cc-sdd): Spec Driven Development Workflow inside Claude-Code ⭐ 50 `🔤 Shell`
+- [Disciplined-AI-Software-Development](https://github.com/Varietyz/Disciplined-AI-Software-Development): Structured approach for collaborating with AI systems on software development projects with constraints and validation checkpoints. ⭐ 267 `🔤 Python`
 
 ## Context Engineering
 
 - [cognitive-load](https://github.com/zakirullin/cognitive-load): 🧠 Cognitive Load is what matters ⭐ 11001
 - [context-engineering-intro](https://github.com/coleam00/context-engineering-intro): Context engineering is the new vibe coding - it's the way to actually make AI coding assistants work. Claude Code is the best for this so that's what this repo is centered around, but you can apply this strategy with any AI coding assistant! ⭐ 9655 `🔤 Python`
-- [Context-Engineering](https://github.com/davidkimai/Context-Engineering): "Context engineering is the delicate art and science of filling the context window with just the right information for the next step." — Andrej Karpathy. A frontier, first-principles handbook inspired by Karpathy and 3Blue1Brown for moving beyond prompt engineering to the wider discipline of context design, orchestration, and optimization. ⭐ 6588 `🔤 Python`
+- [Context-Engineering](https://github.com/davidkimai/Context-Engineering): "Context engineering is the delicate art and science of filling the context window with just the right information for the next step." — Andrej Karpathy. ⭐ 6588 `🔤 Python`
 
-## Claude Code Tools & Extensions
+## Agents & Collaboration
 
-- [superpowers](https://github.com/obra/superpowers): Give Claude Code superpowers with a comprehensive skills library of proven techniques, patterns, and tools.
-- [claude-code-router](https://github.com/musistudio/claude-code-router): Use Claude Code as the foundation for coding infrastructure, allowing you to decide how to interact with the model while enjoying updates from Anthropic. ⭐ 17148 `🔤 TypeScript`
-- [opcode](https://github.com/getAsterisk/opcode): A powerful GUI app and Toolkit for Claude Code - Create custom agents, manage interactive Claude Code sessions, run secure background agents, and more. ⭐ 16019 `🔤 TypeScript`
-- [SuperClaude_Framework](https://github.com/SuperClaude-Org/SuperClaude_Framework): A meta-programming configuration framework that transforms Claude Code into a structured development platform through behavioral instruction injection and component orchestration. It provides systematic workflow automation with powerful tools and intelligent agents. ⭐ 15300
-- [claude-flow](https://github.com/ruvnet/claude-flow): Claude-Flow v2.0.0 Alpha represents a leap in AI-powered development orchestration. Built from the ground up with enterprise-grade architecture, advanced swarm intelligence, and seamless Claude Code integration. ⭐ 7353 `🔤 TypeScript`
-- [zen-mcp-server](https://github.com/BeehiveInnovations/zen-mcp-server): The power of Claude Code / GeminiCLI / CodexCLI + [Gemini / OpenAI / Grok / OpenRouter / Ollama / Custom Model / All Of The Above] working as one. ⭐ 6990 `🔤 Python`
-- [claude-code-templates](https://github.com/davila7/claude-code-templates): Ready-to-use configurations for Anthropic's Claude Code. A comprehensive collection of AI agents, custom commands, settings, hooks, external integrations (MCPs), and project templates to enhance your development workflow. ⭐ 5700
-- [claude-code-templates](https://github.com/davila7/claude-code-templates): CLI tool for configuring and monitoring Claude Code ⭐ 5603 `🔤 JavaScript`
-- [ccpm](https://github.com/automazeio/ccpm): Project management system for Claude Code using GitHub Issues and Git worktrees for parallel agent execution. ⭐ 4296 `🔤 Shell`
-- [claude-context](https://github.com/zilliztech/claude-context): Code search MCP for Claude Code. Make entire codebase the context for any coding agent. ⭐ 3444 `🔤 TypeScript`
-- [awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents): An orchestrated sub agent dev team powered by claude code ⭐ 3144
-- [claude-code-action](https://github.com/anthropics/claude-code-action): None ⭐ 3054 `🔤 TypeScript`
-- [CCPlugins](https://github.com/brennercruvinel/CCPlugins): Best Claude Code framework that actually save time. Built by a dev tired of typing "please act like a senior engineer" in every conversation. ⭐ 2252 `🔤 Python`
-- [claude-code-guide](https://github.com/zebbern/claude-code-guide): Full guide on claude tips and tricks and how you can optimise your claude code the best & strive to find every command possible even hidden ones! ⭐ 2155
-- [claude-code-proxy](https://github.com/1rgs/claude-code-proxy): Run Claude Code on OpenAI models ⭐ 2151 `🔤 Python`
-- [claude-code-requirements-builder](https://github.com/rizethereum/claude-code-requirements-builder): None ⭐ 1563
-- [claude-code-proxy](https://github.com/fuergaosi233/claude-code-proxy): Claude Code to OpenAI API Proxy ⭐ 1395 `🔤 Python`
-- [happy](https://github.com/slopus/happy): Mobile and Web client for Claude Code, with realtime voice, encryption and fully featured ⭐ 1357 `🔤 TypeScript`
-- [zcf](https://github.com/UfoMiao/zcf): Zero-Config Claude-Code Flow ⭐ 1328 `🔤 TypeScript`
-- [vibekit](https://github.com/superagent-ai/vibekit): Run Claude Code, Gemini, Codex — or any coding agent — in a clean, isolated sandbox with sensitive data redaction and observability baked in. ⭐ 1210 `🔤 TypeScript`
-- [ccundo](https://github.com/RonitSachdev/ccundo): ccundo seamlessly integrates with Claude Code to provide granular undo functionality. It reads directly from Claude Code's session files to track file operations and allows you to selectively revert changes with full preview and cascading safety. ⭐ 1081 `🔤 JavaScript`
-- [my-claude-code-setup](https://github.com/centminmod/my-claude-code-setup): Shared starter template configuration and CLAUDE.md memory bank system for Claude Code ⭐ 1077
-- [dotai](https://github.com/udecode/dotai): Ultimate AI development stack: Claude Code + Task Master + Cursor ⭐ 1015 `🔤 Shell`
-- [claude-code-mastering](https://github.com/revfactory/claude-code-mastering): None ⭐ 673 `🔤 JavaScript`
-- [claude-code-cookbook](https://github.com/wasabeef/claude-code-cookbook): A collection of settings to make Claude Code more useful. ⭐ 668 `🔤 Shell`
-- [CCometixLine](https://github.com/Haleclipse/CCometixLine): Claude Code statusline tool written in Rust ⭐ 507 `🔤 Rust`
-- [claude-powerline](https://github.com/Owloops/claude-powerline): Beautiful vim-style powerline statusline for Claude Code ⭐ 335 `🔤 TypeScript`
-
-
-## Agents & Sub-Agents
-
-- [agents](https://github.com/wshobson/agents): A collection of production-ready subagents for Claude Code ⭐ 12096
-- [agent-rules](https://github.com/steipete/agent-rules): Rules and Knowledge to work better with agents such as Claude Code or Cursor ⭐ 4352 `🔤 Shell`
-- [Backlog.md](https://github.com/MrLesk/Backlog.md): Backlog.md - A tool for managing project collaboration between humans and AI Agents in a git ecosystem ⭐ 3221 `🔤 TypeScript`
-- [awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents): Production-ready Claude subagents collection with 100+ specialized AI agents for full-stack development, DevOps, data science, and business operations. ⭐ 2273
-- [claude-agents](https://github.com/iannuttall/claude-agents): Custom subagents to use with Claude Code. ⭐ 1759
-- [claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection): Claude Code Subagents & Commands Collection + CLI Tool ⭐ 1733 `🔤 TypeScript`
-- [claude-swarm](https://github.com/parruda/claude-swarm): Easily launch a Claude Code session that is connected to a swarm of Claude Code Agents ⭐ 1143 `🔤 Ruby`
-- [claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents): Collection of specialized AI subagents for Claude Code for personal use (full-stack development). ⭐ 926
-- [awesome-claude-code-agents](https://github.com/hesreallyhim/awesome-claude-code-agents): A curated list of awesome Claude Code Sub-Agents ⭐ 839
-- [cc-sessions](https://github.com/GWUDCAP/cc-sessions): An opinionated extension set for Claude Code (hooks, subagents, commands, task/git management infrastructure) ⭐ 729 `🔤 Python`
-- [claude-code-unified-agents](https://github.com/stretchcloud/claude-code-unified-agents): None ⭐ 637 `🔤 Shell`
-- [claude-code-settings](https://github.com/feiskyer/claude-code-settings): Claude Code settings, commands and agents for vibe coding ⭐ 463
-- [claude-sub-agent](https://github.com/zhsama/claude-sub-agent): AI-driven development workflow system built on Claude Code Sub-Agents. ⭐ 423
+- [agent-rules](https://github.com/steipete/agent-rules): Rules and knowledge to work better with agents such as Claude Code or Cursor. ⭐ 4352 `🔤 Shell`
+- [Backlog.md](https://github.com/MrLesk/Backlog.md): Manage project collaboration between humans and AI Agents in a git ecosystem. ⭐ 3221 `🔤 TypeScript`
 
 ## Development Tools & Utilities
 
-- [ccusage](https://github.com/ryoppippi/ccusage): A CLI tool for analyzing Claude Code usage from local JSONL files. ⭐ 7855 `🔤 TypeScript`
+- [zen-mcp-server](https://github.com/BeehiveInnovations/zen-mcp-server): Integrate Claude Code, GeminiCLI, CodexCLI, OpenAI, Grok, Ollama, and more in a unified workflow. ⭐ 6990 `🔤 Python`
+- [vibekit](https://github.com/superagent-ai/vibekit): Run Claude Code, Gemini, Codex — or any coding agent — in a clean, isolated sandbox with sensitive data redaction and observability baked in. ⭐ 1210 `🔤 TypeScript`
+- [dotai](https://github.com/udecode/dotai): Ultimate AI development stack combining Claude Code, Task Master, Cursor, and more. ⭐ 1015 `🔤 Shell`
 - [prompts](https://github.com/kingkongshot/prompts): AI 相关的笔记 ⭐ 1646
-- [ccstatusline](https://github.com/sirmalloc/ccstatusline): 🚀 Beautiful highly customizable statusline for Claude Code CLI with powerline support, themes, and more. ⭐ 1047 `🔤 TypeScript`
-- [awesome-ai-coding-tools](https://github.com/ai-for-developers/awesome-ai-coding-tools): A curated list of AI-powered coding tools ⭐ 983
-- [kiro](https://github.com/jasonkneen/kiro): Complete System Prompts for Kiro IDE by Amazon ⭐ 302
 
 ## Awesome Lists & Collections
 
-- [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code): A curated list of awesome commands, files, and workflows for Claude Code ⭐ 13669 `🔤 Python`
+- [awesome-ai-coding-tools](https://github.com/ai-for-developers/awesome-ai-coding-tools): A curated list of AI-powered coding tools. ⭐ 983
 
 ## UI & Interface
 
 - [opencode](https://github.com/sst/opencode): AI coding agent, built for the terminal. ⭐ 22399 `🔤 Go`
-- [claudecodeui](https://github.com/siteboon/claudecodeui): Use Claude Code or Cursor CLI on mobile and web with Claude Code UI. Claude Code UI free open source webui/GUI that helps you manage your Claude Code session and projects remotely ⭐ 3896 `🔤 JavaScript`
 
-## Monitoring & Analytics
+## Claude Code Ecosystem
 
-- [Claude-Code-Usage-Monitor](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor): Real-time Claude Code usage monitor with predictions and warnings ⭐ 4980 `🔤 Python`
+### Frameworks & Methodologies
+
+- [claude-conductor](https://github.com/superbasicstudio/claude-conductor): Claude Conductor - a simple Claude Code framework. ⭐ 188 `🔤 JavaScript`
+- [cc-sdd](https://github.com/pdoronila/cc-sdd): Spec Driven Development workflow inside Claude Code. ⭐ 50 `🔤 Shell`
+- [SuperClaude_Framework](https://github.com/SuperClaude-Org/SuperClaude_Framework): Configuration framework that transforms Claude Code into a structured development platform through automation and orchestration. ⭐ 15300
+
+### Workflow & Automation
+
+- [claude-code-spec-workflow](https://github.com/Pimzino/claude-code-spec-workflow): Automated workflows for Claude Code with spec-driven development and streamlined bug fixes. ⭐ 2599 `🔤 TypeScript`
+- [claude-code-workflows](https://github.com/OneRedOak/claude-code-workflows): Battle-tested Claude Code workflows and configurations used in an AI-native startup. ⭐ 2207
+- [crystal](https://github.com/stravu/crystal): Run multiple Claude Code AI sessions in parallel git worktrees to test and compare approaches. ⭐ 1826 `🔤 TypeScript`
+- [claude-code-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery): Comprehensive guide to Claude Code hooks. ⭐ 1399 `🔤 Python`
+- [spec-workflow-mcp](https://github.com/Pimzino/spec-workflow-mcp): Model Context Protocol server that provides structured spec-driven development workflow tools for Claude Code. ⭐ 1364 `🔤 TypeScript`
+- [Claude-Code-Development-Kit](https://github.com/peterkrueck/Claude-Code-Development-Kit): Handle context at scale with custom Claude Code workflow including hooks, MCP, and sub-agents. ⭐ 1049 `🔤 Shell`
+- [commands](https://github.com/wshobson/commands): Collection of production-ready slash commands for Claude Code. ⭐ 673
+- [Claude-Command-Suite](https://github.com/qdhenry/Claude-Command-Suite): Professional slash commands for Claude Code covering code review, feature creation, auditing, and more. ⭐ 652 `🔤 Shell`
+- [myclaude](https://github.com/cexll/myclaude): Claude Code AI team workflow sub agents. ⭐ 635
+- [claude-commands](https://github.com/badlogic/claude-commands): Global Claude Code commands and workflows. ⭐ 437
+- [claudecode-rule2hook](https://github.com/zxdxjtu/claudecode-rule2hook): Transform natural language project rules into Claude Code automation hooks. ⭐ 355 `🔤 Python`
+
+### Tools & Extensions
+
+- [superpowers](https://github.com/obra/superpowers): Give Claude Code superpowers with a comprehensive skills library of proven techniques, patterns, and tools.
+- [claude-code-router](https://github.com/musistudio/claude-code-router): Use Claude Code as the foundation for coding infrastructure with customizable interaction layers. ⭐ 17148 `🔤 TypeScript`
+- [opcode](https://github.com/getAsterisk/opcode): GUI app and toolkit for Claude Code to create custom agents, manage sessions, and run secure background agents. ⭐ 16019 `🔤 TypeScript`
+- [claude-flow](https://github.com/ruvnet/claude-flow): Enterprise-grade development orchestration built around Claude Code. ⭐ 7353 `🔤 TypeScript`
+- [claude-code-templates](https://github.com/davila7/claude-code-templates): Ready-to-use configurations, agents, commands, hooks, and a CLI for managing Claude Code setups. ⭐ 5700
+- [ccpm](https://github.com/automazeio/ccpm): Project management system for Claude Code using GitHub Issues and git worktrees for parallel agent execution. ⭐ 4296 `🔤 Shell`
+- [claude-context](https://github.com/zilliztech/claude-context): Code search MCP for Claude Code to make the entire codebase available as context. ⭐ 3444 `🔤 TypeScript`
+- [claude-code-action](https://github.com/anthropics/claude-code-action): Official Claude Code GitHub Action. ⭐ 3054 `🔤 TypeScript`
+- [CCPlugins](https://github.com/brennercruvinel/CCPlugins): Claude Code framework built to save time with curated plugins and prompts. ⭐ 2252 `🔤 Python`
+- [claude-code-guide](https://github.com/zebbern/claude-code-guide): Tips, tricks, and hidden commands to optimize Claude Code usage. ⭐ 2155
+- [claude-code-proxy](https://github.com/1rgs/claude-code-proxy): Run Claude Code on OpenAI models. ⭐ 2151 `🔤 Python`
+- [claude-code-proxy](https://github.com/fuergaosi233/claude-code-proxy): Claude Code to OpenAI API proxy. ⭐ 1395 `🔤 Python`
+- [claude-code-requirements-builder](https://github.com/rizethereum/claude-code-requirements-builder): Generate structured requirements for Claude Code projects. ⭐ 1563
+- [happy](https://github.com/slopus/happy): Mobile and web client for Claude Code with realtime voice and encryption. ⭐ 1357 `🔤 TypeScript`
+- [zcf](https://github.com/UfoMiao/zcf): Zero-config Claude Code flow. ⭐ 1328 `🔤 TypeScript`
+- [my-claude-code-setup](https://github.com/centminmod/my-claude-code-setup): Starter template configuration and CLAUDE.md memory bank system for Claude Code. ⭐ 1077
+- [claude-code-mastering](https://github.com/revfactory/claude-code-mastering): Practical guidance for mastering Claude Code. ⭐ 673 `🔤 JavaScript`
+- [claude-code-cookbook](https://github.com/wasabeef/claude-code-cookbook): Collection of settings to make Claude Code more useful. ⭐ 668 `🔤 Shell`
+
+### Agents & Sub-Agents
+
+- [agents](https://github.com/wshobson/agents): Collection of production-ready subagents for Claude Code. ⭐ 12096
+- [awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents): Production-ready Claude subagents collection with 100+ specialized AI agents. ⭐ 2273
+- [claude-agents](https://github.com/iannuttall/claude-agents): Custom subagents to use with Claude Code. ⭐ 1759
+- [claude-code-subagents-collection](https://github.com/davepoon/claude-code-subagents-collection): Claude Code subagents and commands collection with CLI tool. ⭐ 1733 `🔤 TypeScript`
+- [claude-swarm](https://github.com/parruda/claude-swarm): Launch Claude Code sessions connected to a swarm of agents. ⭐ 1143 `🔤 Ruby`
+- [claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents): Specialized Claude Code subagents for full-stack development. ⭐ 926
+- [awesome-claude-code-agents](https://github.com/hesreallyhim/awesome-claude-code-agents): Curated list of Claude Code sub-agents. ⭐ 839
+- [cc-sessions](https://github.com/GWUDCAP/cc-sessions): Opinionated extension set for Claude Code with hooks, subagents, commands, and git management. ⭐ 729 `🔤 Python`
+- [claude-code-unified-agents](https://github.com/stretchcloud/claude-code-unified-agents): Unified Claude Code agents with shared best practices. ⭐ 637 `🔤 Shell`
+- [claude-code-settings](https://github.com/feiskyer/claude-code-settings): Claude Code settings, commands, and agents for vibe coding. ⭐ 463
+- [claude-sub-agent](https://github.com/zhsama/claude-sub-agent): AI-driven development workflow system built on Claude Code sub-agents. ⭐ 423
+
+### Skills Libraries
+
+- [skills](https://github.com/anthropics/skills): Official Anthropic Claude Code skills catalog for extending agents with ready-to-use capabilities.
+- [Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers): Curated Claude Code skill packs focused on streamlining development workflows and automation tasks.
+- [awesome-claude-skills](https://github.com/JayZeeDesign/awesome-claude-skills): Community-maintained list of Claude Code skills, examples, and supporting resources.
+
+### Development Utilities
+
+- [ccusage](https://github.com/ryoppippi/ccusage): CLI tool for analyzing Claude Code usage from local JSONL files. ⭐ 7855 `🔤 TypeScript`
+- [ccundo](https://github.com/RonitSachdev/ccundo): Granular undo functionality for Claude Code sessions with previews and safety checks. ⭐ 1081 `🔤 JavaScript`
+
+### UI & Interface
+
+- [claudecodeui](https://github.com/siteboon/claudecodeui): Remote GUI/WebUI for managing Claude Code sessions on mobile and web. ⭐ 3896 `🔤 JavaScript`
+- [CCometixLine](https://github.com/Haleclipse/CCometixLine): Claude Code statusline tool written in Rust. ⭐ 507 `🔤 Rust`
+- [claude-powerline](https://github.com/Owloops/claude-powerline): Beautiful vim-style powerline statusline for Claude Code. ⭐ 335 `🔤 TypeScript`
+
+### Monitoring & Analytics
+
+- [Claude-Code-Usage-Monitor](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor): Real-time Claude Code usage monitor with predictions and warnings. ⭐ 4980 `🔤 Python`
+
+### Awesome Lists & Collections
+
+- [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code): Curated list of commands, files, and workflows for Claude Code. ⭐ 13669 `🔤 Python`
+
+## Kiro Ecosystem
+
+### Templates & Configs
+
+- [kiro](https://github.com/jasonkneen/kiro): Complete system prompts for Kiro IDE by Amazon. ⭐ 302
+
+## AI Coding Blogs
+
+- [How to Use Claude Code Subagents to Parallelize Development](https://zachwills.net/how-to-use-claude-code-subagents-to-parallelize-development/)
 
 ## Contributing
 
@@ -120,7 +160,7 @@ Contributions are welcome! Please feel free to submit a Pull Request to add new 
 
 This playbook uses **AI-powered smart classification** that analyzes:
 - Repository descriptions and names
-- GitHub topics and tags  
+- GitHub topics and tags
 - Content patterns and keywords
 - Development context and purpose
 
@@ -128,11 +168,6 @@ The classification prioritizes **methodology-focused categories**:
 1. **AI Coding Frameworks** - Core development frameworks and methodologies
 2. **Workflow & Automation** - Development workflows and automation tools
 3. **Context Engineering** - Context management and optimization techniques
-
-## AI Coding Blogs
-
-- [How to Use Claude Code Subagents to Parallelize Development](https://zachwills.net/how-to-use-claude-code-subagents-to-parallelize-development/)
-
 
 ## License
 
@@ -143,4 +178,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - Thanks to all the contributors who have shared their amazing AI coding tools and frameworks
 - Inspired by the awesome list movement and the growing AI coding community
 - Generated automatically by AI Coding Playbook Builder with smart classification
-


### PR DESCRIPTION
## Summary
- restructure the README to highlight general resources separately from tool-specific ecosystems
- group Claude Code content into dedicated subsections including frameworks, workflows, tools, agents, skills, and more
- introduce a Kiro ecosystem section and relocate multi-tool resources to general categories

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68fb2b979558832b9670b7990f3f4064